### PR TITLE
[WIP] ユーザー追加テストの作成及びスケジュールへの登録

### DIFF
--- a/src/app/Console/Commands/AddUserTest.php
+++ b/src/app/Console/Commands/AddUserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use phpQuery;
+
+function generateRandomPassword()
+{
+    $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+    $pass = array();
+    $alphaLength = strlen($alphabet) - 1;
+    for ($i = 0; $i < 8; $i++) {
+        $n = rand(0, $alphaLength);
+        $pass[] = $alphabet[$n];
+    }
+    return implode($pass);
+}
+
+class AddUserTest extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test:addUser {name} {email} {--password=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add user';
+
+    protected $registerUrl = 'http://nginx/register';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $password = $this->option('password') ? $this->option('password') : generateRandomPassword();
+        $sessionInfomation = $this->getSessionInfomation();
+
+        $request_data = array(
+            '_token'  => $sessionInfomation->csrfToken,
+            'name' => $this->argument('name'),
+            'email' => $this->argument('email'),
+            'password' => $password,
+            'password_confirmation' => $password
+        );
+
+        $header = (
+            "Content-type: application/x-www-form-urlencoded\r\n"
+          . "Cookie: " . implode(";", $sessionInfomation->cookies) . "\r\n"
+        );
+
+        $this->line('Name      : ' . $request_data['name']);
+        $this->line('Email     : ' . $request_data['email']);
+        $this->line('Password  : ' . $request_data['password']);
+
+        $options = array(
+            'http' => array(
+                'header'  => $header,
+                'method'  => 'POST',
+                'content' => http_build_query($request_data),
+            )
+        );
+
+        $context  = stream_context_create($options);
+        $html = file_get_contents($this->registerUrl, false, $context);
+
+        $validationErrors = phpQuery::newDocument($html)->find('.help-block')->find('strong')->text();
+        if ($validationErrors) {
+            $this->error("\nvalidation errors");
+            $this->info($validationErrors);
+        } else {
+            $this->info('Success');
+        };
+
+        // var_dump($result);
+    }
+
+    protected function getSessionInfomation()
+    {
+        $html = file_get_contents($this->registerUrl);
+
+        $cookies = [];
+        foreach ($http_response_header as $s) {
+            if (preg_match("/Set-Cookie:\s*([^=]+)=([^;]+);(.+)/u", $s, $parts)) {
+                $cookies[] = $parts[1] . '=' . $parts[2];
+            }
+        }
+
+        $csrfTokenElement = phpQuery::newDocument($html)->find("form")->find(':input[name=_token]');
+        return (object) array(
+            "cookies" => $cookies,
+            "csrfToken" => $csrfTokenElement->val()
+        );
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -24,8 +24,12 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $schedule->command('test:addUser', ['test-user1', 'test@example.com'])
+            ->everyMinute()
+            ->before(function () {
+                // タスク開始時…
+            })
+            ->appendOutputTo("/var/log/laravel/test/addUser.log");
     }
 
     /**

--- a/src/composer.json
+++ b/src/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
+        "electrolinux/phpquery": "^0.9.6",
         "fideloper/proxy": "~3.3",
         "laravel/framework": "5.5.*",
         "laravel/tinker": "~1.0"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2892059d37b8f2290af9dc0ad9f72671",
+    "content-hash": "0cb5186443cc6d3b1b1141e0b4a26228",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -216,6 +216,46 @@
                 "validator"
             ],
             "time": "2018-12-04T22:38:24+00:00"
+        },
+        {
+            "name": "electrolinux/phpquery",
+            "version": "0.9.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/electrolinux/phpquery.git",
+                "reference": "6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/electrolinux/phpquery/zipball/6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a",
+                "reference": "6cb8afcfe8cd4ce45f2f8c27d561383037c27a3a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "phpQuery/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobiasz Cudnik",
+                    "email": "tobiasz.cudnik@gmail.com",
+                    "homepage": "https://github.com/TobiaszCudnik",
+                    "role": "Developer"
+                },
+                {
+                    "name": "didier Belot",
+                    "role": "Packager"
+                }
+            ],
+            "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
+            "homepage": "http://code.google.com/p/phpquery/",
+            "time": "2013-03-21T12:39:33+00:00"
         },
         {
             "name": "erusev/parsedown",


### PR DESCRIPTION
# 概要
ユーザー追加機能をartisan commandとして追加
毎分ユーザ追加コマンドを実行する

#  ユーザー追加コマンド
**使用方法**
```
php artisan test:addUser [OPTIONS] ユーザ名 メールアドレス
Options: 
  --password=<password>
```
パスワードを指定しない場合はランダムで作成される

**実装**
スクレイピングのために[PhpQuery](https://github.com/punkave/phpQuery)を使用

1. `GET:/register` にアクセスし、CSRF tokenとCookieのSession情報を取得
2. `POST:/register` へと引数から取得した作成ユーザー情報とCSRF token, CookieのSession情報を送信
3. Responseのhtmlからバリデーションエラーをスクレイピング

# ユーザー追加コマンドの定期実行

毎分、下記コマンドを実行
`php artisan test:addUser test-user1 test@example.com` 

Cronへと下記スケジュール追加
```
* * * * * php /var/www/artisan schedule:run 1>> /dev/null 2>&1
```

実行ログは `/var/log/laravel/test/addUser.log` へと追記される様実装